### PR TITLE
#32 bug/storage-delete

### DIFF
--- a/src/components/AdminDashboard/addProduct/AddProduct.jsx
+++ b/src/components/AdminDashboard/addProduct/AddProduct.jsx
@@ -34,7 +34,7 @@ const AddProduct = () => {
   };
 
   useEffect(() => {
-    file && uploadFiles(file, setProgress, setData);
+    file && uploadFiles(file, setProgress, setData, data.product);
   }, [file]);
 
   return (

--- a/src/components/AdminDashboard/products/ProductList.jsx
+++ b/src/components/AdminDashboard/products/ProductList.jsx
@@ -5,16 +5,20 @@ import Box from "@mui/material/Box";
 import { DataGrid } from "@mui/x-data-grid";
 import { db } from "../../../firebase";
 import { collection, onSnapshot } from "firebase/firestore";
-import { Avatar, Button } from "@mui/material";
-import { deleteInitiate } from "../../../redux/modules/actions/productActions";
+import { Avatar } from "@mui/material";
+import {
+  deleteInitiate,
+  deleteStorageFile,
+} from "../../../redux/modules/actions/productActions";
 
 function ProductList() {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
 
-  const deleteHandler = (id, img) => {
-    dispatch(deleteInitiate(id, img));
+  const deleteHandler = (id, name) => {
+    dispatch(deleteInitiate(id));
+    deleteStorageFile(name);
   };
 
   useEffect(() => {
@@ -44,7 +48,7 @@ function ProductList() {
         field: "image",
         headerName: "Image",
         sortable: false,
-        width: 60,
+        width: 80,
         renderCell: (params) => <Avatar src={params.row.img} />,
         filterable: false,
       },
@@ -58,7 +62,7 @@ function ProductList() {
         field: "product",
         headerName: "Product",
         sortable: false,
-        width: 200,
+        width: 220,
       },
       {
         field: "price",
@@ -70,7 +74,7 @@ function ProductList() {
         field: "desc",
         headerName: "Desc",
         sortable: false,
-        width: 250,
+        width: 270,
       },
       {
         field: "edit",
@@ -82,7 +86,7 @@ function ProductList() {
         headerName: "Delete",
         renderCell: (params) => (
           <DeleteButton
-            onClick={() => deleteHandler(params.row.id, params.row.img)}
+            onClick={() => deleteHandler(params.row.id, params.row.product)}
           >
             Delete
           </DeleteButton>
@@ -101,7 +105,6 @@ function ProductList() {
           rows={data}
           columns={columns}
           pageSize={10}
-          checkboxSelection
           disableSelectionOnClick
           getRowId={(row) => row.id}
         />

--- a/src/redux/modules/actions/productActions.jsx
+++ b/src/redux/modules/actions/productActions.jsx
@@ -34,8 +34,8 @@ export const addInitiate = (data) => {
 };
 
 // Storage에 image파일 저장하기
-export const uploadFiles = (file, setProgress, setData) => {
-  const uploadRef = ref(storage, `images/${file.name}`);
+export const uploadFiles = async (file, setProgress, setData, name) => {
+  const uploadRef = ref(storage, `images/${name}`);
   const uploadTask = uploadBytesResumable(uploadRef, file);
 
   uploadTask.on(
@@ -66,18 +66,21 @@ export const uploadFiles = (file, setProgress, setData) => {
   );
 };
 
-export const deleteInitiate = (id, file) => {
+// Firebase Database에 있는 데이터 삭제
+export const deleteInitiate = (id) => {
   return async function (dispatch) {
     await deleteDoc(doc(productCollectionRef, id));
     dispatch(deleteProducts());
-
-    // const deleteRef = ref(storage, `images/${file.name}`);
-    // deleteObject(deleteRef)
-    //   .then(() => {
-    //     console.log("success");
-    //   })
-    //   .catch((error) => {
-    //     console.log(error);
-    //   });
   };
+};
+
+// Storage에 있는 Image 삭제
+export const deleteStorageFile = async (name) => {
+  try {
+    const deleteRef = ref(storage, `images/${name}`);
+    await deleteObject(deleteRef);
+    console.log("success");
+  } catch (error) {
+    console.log(error);
+  }
 };


### PR DESCRIPTION
Storage에 저장되는이미지의 이름을 product의 이름으로 저장하여 삭제 할 때도 product의 이름을 삭제 할 수 있도록 하였다.
=> name이란 변수에 동일하게 data의 product가 들어 갈 수 있게끔 하였다.

```
// Storage에 image파일 저장하기
export const uploadFiles = async (file, setProgress, setData, name) => {
  const uploadRef = ref(storage, `images/${name}`);
  const uploadTask = uploadBytesResumable(uploadRef, file);

  uploadTask.on(
    "state_changed",
    (snapshot) => {
      const uploadProgress = Math.round(
        (snapshot.bytesTransferred / snapshot.totalBytes) * 100
      );
      setProgress(uploadProgress);

      switch (snapshot.state) {
        case "paused":
          console.log("Upload is Pause");
          break;
        case "running":
          console.log("Upload is Running");
          break;
        default:
          break;
      }
    },
    (err) => console.log(err),
    () => {
      getDownloadURL(uploadTask.snapshot.ref).then((downloadUrl) =>
        setData((prev) => ({ ...prev, img: downloadUrl }))
      );
    }
  );
};
```
```
// Storage에 있는 Image 삭제
export const deleteStorageFile = async (name) => {
  try {
    const deleteRef = ref(storage, `images/${name}`);
    await deleteObject(deleteRef);
    console.log("success");
  } catch (error) {
    console.log(error);
  }
};
```
closes #32