### PR TITLE
bug/admin-userlist

### DIFF
--- a/src/components/AdminDashboard/users/UserList.jsx
+++ b/src/components/AdminDashboard/users/UserList.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import Box from "@mui/material/Box";
 import { DataGrid } from "@mui/x-data-grid";
@@ -9,7 +9,7 @@ import { useNavigate } from "react-router-dom";
 import Loading from "../../loading/Loading";
 import { deleteInitiate } from "../../../redux/modules/actions/userActions";
 
-function ProductList() {
+function UserList() {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
@@ -174,4 +174,4 @@ const ViewButton = styled.button`
   }
 `;
 
-export default ProductList;
+export default UserList;

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -10,7 +10,6 @@ import {
   googleLoginInitiate,
   githubLoginInitiate,
   loginInitiate,
-  addInitiate,
 } from "../../redux/modules/actions/userActions";
 import { loginSchema } from "../../components/Auth/AuthSchema/LoginSchema";
 

--- a/src/pages/signup/Signup.jsx
+++ b/src/pages/signup/Signup.jsx
@@ -9,6 +9,7 @@ import { useFormik } from "formik";
 import { signupSchema } from "../../components/Auth/AuthSchema/SignupSchema";
 import { addDoc, collection } from "firebase/firestore";
 import { db } from "../../firebase";
+import { addUsers } from "../../redux/modules/actions/userActions";
 
 const Signup = () => {
   const { currentUser } = useSelector((state) => state.user);
@@ -35,6 +36,7 @@ const Signup = () => {
       validationSchema: signupSchema,
       onSubmit: async (values) => {
         dispatch(registerInitiate(values.email, values.password));
+        dispatch(addUsers(values));
 
         await addDoc(collection(db, "users"), { values });
 


### PR DESCRIPTION
소셜 로그인을 했을 경우 관리자 페이지의 가입한 유저목록에 동일한 유저가 계속 생기는 버그가 발생하였고
```
const setSocialUser = async (user) => {
  let username = user.displayName;
  let email = user.email;
  let photoURL = user.photoURL;
  let phoneNumber = user.phoneNumber;

  await setDoc(doc(db, "users", user.uid), {
    username,
    email,
    photoURL,
    phoneNumber,
  });
};
```
유저의 고유 uid 값을 firestore에 저장되는 id 값으로 대체하여 반복 저장되는 것을 방지

closes #45 
closes #43