### PR TITLE
[Bug] #55 #57 

### DIFF
--- a/src/components/AdminDashboard/MainContent.jsx
+++ b/src/components/AdminDashboard/MainContent.jsx
@@ -10,7 +10,6 @@ import EditProduct from "../AdminDashboard/editProduct/EditProduct";
 import UserView from "../AdminDashboard/users/UserView";
 
 const MainContent = () => {
-  useEffect(() => {}, []);
   return (
     <>
       <Routes>

--- a/src/components/AdminDashboard/editProduct/EditProduct.jsx
+++ b/src/components/AdminDashboard/editProduct/EditProduct.jsx
@@ -1,13 +1,9 @@
 import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import Category from "../addProduct/Category";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
-import {
-  getProductInitiate,
-  getProducts,
-  updateInitiate,
-} from "../../../redux/modules/actions/productActions";
+import { updateInitiate } from "../../../redux/modules/actions/productActions";
 import { uploadFiles } from "../../../redux/modules/actions/productActions";
 import Loading from "../../loading/Loading";
 
@@ -20,7 +16,6 @@ const EditProduct = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { productId } = useParams();
-  const { products } = useSelector((state) => state.addProduct);
 
   const handleChange = (e) => {
     setData({ ...data, [e.target.name]: e.target.value });
@@ -42,7 +37,6 @@ const EditProduct = () => {
 
   useEffect(() => {
     file && uploadFiles(file, setProgress, setData, data.product);
-    // setData(products)
   }, [file]);
 
   return (

--- a/src/components/AdminDashboard/products/ProductList.jsx
+++ b/src/components/AdminDashboard/products/ProductList.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from "react";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import styled from "styled-components";
 import Box from "@mui/material/Box";
 import { DataGrid } from "@mui/x-data-grid";
@@ -17,8 +17,6 @@ function ProductList() {
   const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { products } = useSelector((state) => state.addProduct);
-  console.log(products);
 
   const deleteHandler = (id, name) => {
     dispatch(deleteInitiate(id));
@@ -30,7 +28,7 @@ function ProductList() {
     setLoading(false);
 
     return () => {
-      unsubscribe(setData);
+      dispatch(unsubscribe(setData));
     };
   }, []);
 

--- a/src/components/home/products/Products.jsx
+++ b/src/components/home/products/Products.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import styled from "styled-components";
 import { MdPets } from "react-icons/md";
 import { unsubscribe } from "../../../redux/modules/actions/productActions";
@@ -8,6 +8,7 @@ import Loading from "../../loading/Loading";
 const Products = () => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
+  const dispatch = useDispatch();
   const { products } = useSelector((state) => state.addProduct);
   console.log(products);
 
@@ -15,13 +16,9 @@ const Products = () => {
     setLoading(false);
 
     return () => {
-      unsubscribe(setData);
+      dispatch(unsubscribe(setData));
     };
   }, []);
-
-  useEffect(() => {
-    if (products) return;
-  }, [products]);
 
   return (
     <ProductContainer>

--- a/src/redux/modules/actions/productActions.jsx
+++ b/src/redux/modules/actions/productActions.jsx
@@ -25,8 +25,9 @@ const addProducts = (data) => ({
   payload: data,
 });
 
-const deleteProducts = () => ({
+export const deleteProducts = (id) => ({
   type: types.DELETE_PRODUCT,
+  payload: id,
 });
 
 const editProducts = (data) => ({
@@ -34,23 +35,32 @@ const editProducts = (data) => ({
   payload: data,
 });
 
+const getProducts = (data) => ({
+  type: types.GET_PRODUCTS,
+  payload: data,
+});
+
 const productCollectionRef = collection(db, "products");
 
-export const unsubscribe = (setData) =>
-  onSnapshot(
-    productCollectionRef,
-    (snapshot) => {
-      let list = [];
-      snapshot.docs.forEach((doc) => {
-        list.push({ id: doc.id, ...doc.data() });
-      });
-      setData(list);
-      setLoading(false);
-    },
-    (err) => {
-      console.log(err);
-    }
-  );
+export const unsubscribe = (setData) => {
+  return function (dispatch) {
+    onSnapshot(
+      productCollectionRef,
+      (snapshot) => {
+        let list = [];
+        snapshot.docs.forEach((doc) => {
+          list.push({ id: doc.id, ...doc.data() });
+        });
+        setData(list);
+        setLoading(false);
+        dispatch(getProducts(list));
+      },
+      (err) => {
+        console.log(err);
+      }
+    );
+  };
+};
 
 // Firebase Database에 있는 데이터 추가
 export const addInitiate = (data) => {
@@ -98,7 +108,7 @@ export const uploadFiles = (file, setProgress, setData, name) => {
 export const deleteInitiate = (id) => {
   return async function (dispatch) {
     await deleteDoc(doc(productCollectionRef, id));
-    dispatch(deleteProducts());
+    dispatch(deleteProducts(id));
   };
 };
 

--- a/src/redux/modules/reducer/productReducer.jsx
+++ b/src/redux/modules/reducer/productReducer.jsx
@@ -3,11 +3,15 @@ import * as types from "../actionTypes/productActionTypes";
 const initialState = {
   loading: false,
   products: [],
-  product: {},
 };
 
 const productReducer = (state = initialState, action) => {
   switch (action.type) {
+    case types.GET_PRODUCTS:
+      return {
+        ...state,
+        products: action.payload,
+      };
     case types.SET_LOADING:
       return {
         ...state,
@@ -18,10 +22,12 @@ const productReducer = (state = initialState, action) => {
         products: [...state.products, action.payload],
       };
     case types.DELETE_PRODUCT:
-      const deleteId = action.payload;
-      state.products = state.products.filter(
-        (product) => product.id !== deleteId
-      );
+      return {
+        ...state.products,
+        products: state.products.filter(
+          (product) => product.id !== action.payload
+        ),
+      };
     case types.EDIT_PRODUCT:
       const updateProduct = action.payload;
       const updateProducts = state.products.map((product) => {


### PR DESCRIPTION
### 상품의 삭제 및 업데이트 버튼을 누르면 products 배열에 해당 상품만 삭제가 되어야하는데 모든 상품이 삭제 또는 업데이트가 되는 버그 발생

### 문제점 
 data에는 id 값을 unsubscribe 함수에서 넣어주고 있었는데 products의  상태에는 id 값이 존재 하지 않았다.

### 해결방법
Firestore에 저장되는 데이터를 setData와 getProducts에 둘다 넣어서 같은 배열을 같게 만들어 주고 상품 리스트에 보여지도록 하였다.
```
export const unsubscribe = (setData) => {
  return function (dispatch) {
    onSnapshot(
      productCollectionRef,
      (snapshot) => {
        let list = [];
        snapshot.docs.forEach((doc) => {
          list.push({ id: doc.id, ...doc.data() });
        });
        setData(list);
        setLoading(false);
        dispatch(getProducts(list));
      },
      (err) => {
        console.log(err);
      }
    );
  };
};
```
```
  useEffect(() => {
    setLoading(false);

    return () => {
      dispatch(unsubscribe(setData));
    };
  }, []);
```

closes #55 
closes #57