### PR TITLE
bug/cart-order-routing

### DIFF
--- a/src/components/AdminDashboard/orders/OrderList.jsx
+++ b/src/components/AdminDashboard/orders/OrderList.jsx
@@ -1,135 +1,27 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import styled from "styled-components";
-import Box from "@mui/material/Box";
-import { DataGrid } from "@mui/x-data-grid";
-import { Avatar } from "@mui/material";
-import { unsubscribe } from "../../../redux/modules/actions/userActions";
-import { useNavigate } from "react-router-dom";
-import Loading from "../../loading/Loading";
-import { deleteInitiate } from "../../../redux/modules/actions/userActions";
 import { deleteOrderInitiate } from "../../../redux/modules/actions/orderActions";
 
-function UserList() {
+const OrderList = () => {
   const { orderItems } = useSelector((state) => state.orderProduct);
-  const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(false);
   const dispatch = useDispatch();
-  const navigate = useNavigate();
-
   const deleteHandler = () => {
     dispatch(deleteOrderInitiate());
 
     alert("해당 유저를 삭제하시겠습니까?");
   };
 
-  console.log(data);
-
-  const columns = useMemo(
-    () => [
-      {
-        field: "photoURL",
-        headerName: "Image",
-        sortable: false,
-        width: 80,
-        filterable: false,
-      },
-      {
-        field: "username",
-        headerName: "UserName",
-        sortable: false,
-        width: 150,
-      },
-      {
-        field: "email",
-        headerName: "Email",
-        sortable: false,
-        width: 250,
-      },
-      {
-        field: "phonenumber",
-        headerName: "PhoneNumber",
-        sortable: false,
-        width: 200,
-      },
-      {
-        field: "delete",
-        headerName: "Delete",
-        renderCell: (params) => (
-          <DeleteButton onClick={() => deleteHandler()}>Delete</DeleteButton>
-        ),
-      },
-    ],
-    []
-  );
-
+  console.log(orderItems);
   return (
-    <>
-      {loading ? (
-        <Loading />
-      ) : (
-        <ListContainer>
-          <Box sx={{ height: "75.5%", width: "82%" }}>
-            <DataGrid
-              rows={data}
-              columns={columns}
-              pageSize={10}
-              disableSelectionOnClick
-              getRowId={(row) => row.id}
-              sx={{
-                borderColor: "primary.light",
-                boxShadow: 2,
-                border: 2,
-                marginTop: 5,
-                paddingLeft: 1,
-                "& .MuiDataGrid-cell:hover": {
-                  color: "primary.main",
-                },
-              }}
-            />
-          </Box>
-        </ListContainer>
-      )}
-    </>
+    <div>
+      {orderItems.map((item, index) => (
+        <div key={index}>
+          <h4>{item.Order.address}</h4>
+          <button onClick={() => deleteHandler(item.Order.id)}>삭제</button>
+        </div>
+      ))}
+    </div>
   );
-}
+};
 
-const ListContainer = styled.div`
-  padding: 5% 0 0 10%;
-  width: 75%;
-  height: 100%;
-`;
-
-const DeleteButton = styled.button`
-  width: 60px;
-  height: 30px;
-  background: none;
-  background-color: red;
-  color: white;
-  font-weight: bold;
-  border: none;
-  border-radius: 8px;
-  &:hover {
-    background-color: white;
-    color: red;
-    transition: all 0.5s ease;
-  }
-`;
-
-const ViewButton = styled.button`
-  width: 60px;
-  height: 30px;
-  background: none;
-  background-color: #007fff;
-  color: white;
-  font-weight: bold;
-  border: none;
-  border-radius: 8px;
-  &:hover {
-    background-color: white;
-    color: #007fff;
-    transition: all 0.5s ease;
-  }
-`;
-
-export default UserList;
+export default OrderList;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,11 +9,9 @@ import { PersistGate } from "redux-persist/integration/react";
 const root = ReactDOM.createRoot(document.getElementById("root"));
 const persistor = persistStore(store);
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <PersistGate loading={null} persistor={persistor}>
-        <App />
-      </PersistGate>
-    </Provider>
-  </React.StrictMode>
+  <Provider store={store}>
+    <PersistGate loading={null} persistor={persistor}>
+      <App />
+    </PersistGate>
+  </Provider>
 );

--- a/src/pages/cart/Cart.jsx
+++ b/src/pages/cart/Cart.jsx
@@ -1,15 +1,9 @@
-import React, { useEffect } from "react";
+import React from "react";
 import Header from "../../components/header/Header";
 import Footer from "../../components/footer/Footer";
 import CartContainer from "../../components/cart/CartContainer";
-import { useNavigate, useLocation } from "react-router-dom";
-import { useSelector } from "react-redux";
 
 const Cart = () => {
-  const { currentUser } = useSelector((state) => state.user);
-  const { pathname } = useLocation();
-  const navigate = useNavigate();
-
   return (
     <>
       <Header />

--- a/src/pages/login/Login.jsx
+++ b/src/pages/login/Login.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { AiOutlineGithub } from "react-icons/ai";
@@ -14,12 +14,13 @@ import {
 import { loginSchema } from "../../components/Auth/AuthSchema/LoginSchema";
 
 const Login = () => {
-  const { currentUser } = useSelector((state) => state.user);
   const error = useSelector((state) => state.user.error);
+  const { currentUser } = useSelector((state) => state.user);
   const [errorMessage, setErrorMessage] = useState("");
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { state } = useLocation();
+  const location = useLocation();
+  const origin = location.state?.from?.pathname;
 
   const initialValues = {
     email: "",
@@ -45,10 +46,6 @@ const Login = () => {
     try {
       setErrorMessage("");
       await dispatch(googleLoginInitiate());
-
-      setTimeout(() => {
-        navigate("/");
-      }, 2000);
     } catch (error) {
       setErrorMessage("Google 로그인 실패");
     }
@@ -58,28 +55,24 @@ const Login = () => {
     try {
       setErrorMessage("");
       await dispatch(githubLoginInitiate());
-      setTimeout(() => {
-        if (state) {
-          navigate(state);
-        } else {
-          navigate("/");
-        }
-      }, 3000);
     } catch (error) {
       setErrorMessage("Github 로그인 실패");
     }
   };
 
-  // useEffect(() => {
-  //   if (currentUser) {
-  //     navigate("/");
-  //   }
-  // }, [currentUser]);
+  useEffect(() => {
+    if (currentUser && origin) {
+      navigate(origin);
+    }
+    if (currentUser && !origin) {
+      navigate("/");
+    }
+  }, [currentUser, origin]);
 
   return (
     <LoginContainer>
       <FormWrapper>
-        <LoginForm onSubmit={handleSubmit}>
+        <LoginForm type="submit" onSubmit={handleSubmit}>
           <FormTitle to="/">LOGIN</FormTitle>
           {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
           <InputField>
@@ -121,10 +114,10 @@ const Login = () => {
           <SubmitBtn>로그인</SubmitBtn>
           <Boundary>--- SOCIAL LOGIN ---</Boundary>
           <SocialLogin>
-            <SocialLoginBtn onClick={handleGoogleLogin}>
+            <SocialLoginBtn type="button" onClick={() => handleGoogleLogin()}>
               <GoogleIcon>구글 로그인</GoogleIcon>
             </SocialLoginBtn>
-            <SocialLoginBtn onClick={handleGithubLogin}>
+            <SocialLoginBtn type="button" onClick={() => handleGithubLogin()}>
               <GithubIcon>깃허브 로그인</GithubIcon>
             </SocialLoginBtn>
           </SocialLogin>

--- a/src/pages/order/Order.jsx
+++ b/src/pages/order/Order.jsx
@@ -1,19 +1,6 @@
-import React, { useEffect } from "react";
-import { useSelector } from "react-redux";
-import { useNavigate, useLocation } from "react-router-dom";
+import React from "react";
 
 const Order = () => {
-  const { currentUser } = useSelector((state) => state.user);
-  const { pathname } = useLocation();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!currentUser) {
-      navigate("/login", { state: pathname });
-    }
-  }, []);
-  console.log(pathname);
-
   return <h1>Order</h1>;
 };
 

--- a/src/pages/privateRoute/PrivateRoute.jsx
+++ b/src/pages/privateRoute/PrivateRoute.jsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useSelector } from "react-redux";
 
 const PrivateRoute = ({ children }) => {
   const { currentUser } = useSelector((state) => state.user);
+  const location = useLocation();
 
   if (!currentUser) {
-    return <Navigate to="/login" />;
+    return <Navigate to="/login" replace state={{ from: location }} />;
   }
   return children;
 };


### PR DESCRIPTION
### 비로그인 상태에서 장바구니에 추가한 상품을 구매할 때,  로그인 페이지로 이동하게되고 로그인이 성공하면 /order인 주문하기 페이지로 이동하게 된다.
### 여기서 이슈 발생!!!😥

### 갑자기 로그인을 두번을 해야 주문하기 페이지로 넘어가는 이슈 발생..
---
### 해결 
#### 일단 로그인이 필요한 페이지는 로그인된 유저가 없을 때, 그 페이지의 state와 함께 로그인 페이지로 이동
```
import React from "react";
import { Navigate, useLocation } from "react-router-dom";
import { useSelector } from "react-redux";

const PrivateRoute = ({ children }) => {
  const { currentUser } = useSelector((state) => state.user);
  const location = useLocation();

  if (!currentUser) {
    return <Navigate to="/login" replace state={{ from: location }} />;
  }
  return children;
};

export default PrivateRoute;
```
#### 로그인 페이지에서 useEffect를 이용해서 origin과 currentUser의 유무에따라 routing을 해주었다.
#### 의존성배열에는 origin과 currentUser를 넣어줌으로써 두 값이 다를 때마다 effect를 실행하게 구현하였다.
```
 const { currentUser } = useSelector((state) => state.user);
 const origin = location.state?.from?.pathname;
useEffect(() => {
    if (currentUser && origin) {
      navigate(origin);
    }
    if (currentUser && !origin) {
      navigate("/");
    }
  }, [currentUser, origin]);
```
closes #111 