### PR TITLE
fix/home-slider

### DIFF
--- a/src/components/home/slider/Slider.jsx
+++ b/src/components/home/slider/Slider.jsx
@@ -53,7 +53,7 @@ const Slider = () => {
 
 const SlideContainer = styled.div`
   position: relative;
-  width: 1750px;
+  width: 1910px;
   height: 350px;
   overflow: hidden;
   @media screen and (max-width: 768px) {


### PR DESCRIPTION
## 목적
page/home에서 쓰이는 이벤트 슬라이더의 비율이 맞지 않는 오류 수정
## 작업 상세 내용
width를 늘려줘서 비율이 맞게 설정하였다.